### PR TITLE
First last fix

### DIFF
--- a/ask_cmr.py
+++ b/ask_cmr.py
@@ -54,7 +54,9 @@ def main():
         if args.collection and granules:
             entries = cmr.get_collection_granules(args.collection, pretty=pretty, descending=args.descending)
         elif args.collection and firstlast:
-            entries = cmr.get_collection_granules(args.collection, pretty=pretty)
+            entries = cmr.get_collection_granules_umm_first_last(args.collection, pretty=pretty)
+            #entries = cmr.get_collection_granules_first_last(args.collection, pretty=pretty)
+            # entries = cmr.get_collection_granules(args.collection, pretty=pretty)
         elif args.collection:
             entries = cmr.get_collection_entry(args.collection, pretty=pretty, count=args.count)
         elif args.resty_path:

--- a/cmr.py
+++ b/cmr.py
@@ -76,7 +76,7 @@ def collection_granules_dict(json_resp):
     This function processes the return information from a granules.json request.
     Do not use it for a granules.umm_json request.
 
-    :param: json_resp: CMR JSON response
+    :param json_resp: CMR JSON response
     :return: A dictionary with the Granule id indexing the producer granule id and granule title
     :rtype: dict
     """
@@ -99,7 +99,7 @@ def collection_granule_and_url_dict(json_resp):
     This function processes the return information from a granules.json request.
     Do not use it for a granules.umm_json request.
 
-    :param: json_resp: CMR JSON response
+    :param json_resp: CMR JSON response
     :return: A dictionary with the Granule id indexing the granule title and OPeNDAP URL
     :rtype: dict
     :deprecated: jhrg 1/23/23
@@ -148,9 +148,8 @@ def provider_id(json_resp):
     The JSON passed to this function is an Array of 'items' each of which holds
     a dictionary with a single key 'meta'. The value of the 'meta' key is itself
     a dictionary that holds lots of info, including the provider-id key-value pair.
-
-    :param: json_resp: CMR JSON response
-    :return: The provider ids in a set
+    :param json_resp: CMR JSON response
+    :returns: The provider ids in a set
     :rtype: set
     """
     if not is_item_feed(json_resp):
@@ -175,9 +174,11 @@ def granule_ur_dict(json_resp):
     jhrg 1/23/23
 
     :param json_resp: CMR JSON UMM response
-    :return: The granule UR related URL info in a dictionary. Only Type 'GET DATA'
+    :returns: The granule UR related URL info in a dictionary. Only Type 'GET DATA'
         or 'USE SERVICE API' with Subtype 'OPENDAP DATA' type URLs are included.
-        Each is indexed using 'URL1', ..., 'URLn.'
+        Each is indexed using 'URL1', ..., 'URLn.' The dictionaries look like:
+        {'URL1': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc',
+         'URL2': 'https://archive/250_2101_ovw.l2.nc'}
     :rtype: dict
     """
     # Check json_resp as above but for items, etc. jhrg 10/11/22
@@ -214,9 +215,11 @@ def granule_ur_dict_2(json_resp):
     jhrg 1/23/23
 
     :param json_resp: CMR JSON UMM response
-    :return: The granule UR related URL info in a dictionary. Only Type 'GET DATA'
+    :returns: The granule UR related URL info in a dictionary. Only Type 'GET DATA'
         or 'USE SERVICE API' with Subtype 'OPENDAP DATA' type URLs are included.
-        Each is indexed using 'URL1', ..., 'URLn.'
+        Each is indexed using the granule concept ID and looks like:
+        {'G2081588885-POCLOUD': ('ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                 'https://opendap.../podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc')}
     :rtype: dict
     """
     # Check json_resp as above but for items, etc. jhrg 10/11/22
@@ -272,7 +275,7 @@ def convert(a: list) -> dict:
     Convert and array of 2N things to a dictionary of N entries
     See https://www.geeksforgeeks.org/python-convert-a-list-to-dictionary/
 
-    :param: a: The List/Array to convert
+    :param a: The List/Array to convert
     :return: The resulting dictionary
     :rtype: dict
     """
@@ -287,14 +290,13 @@ def process_request(cmr_query_url, response_processor, session, page_size=10, pa
     and return the number of entries. The page_size parameter is there so that paged responses
     can be handled. By default, CMR returns 10 entry items per page.
 
-    :param: cmr_query_url: The whole URL, query params and all
-    :param: response_processor: A function that will process the returned json response
-    :param: session: A requests package session object
-    :param: page_size: The number of entries per page from CMR. The default is the CMR
-        default value.
-    :param: page_num: Return an explicit page of the query response. If not given, gets all
-        the pages
+    :param cmr_query_url: The whole URL, query params and all
+    :param response_processor: A function that will process the returned json response
+    :param session: A requests package session object
+    :param page_size: The number of entries per page from CMR. The default is the CMR default value.
+    :param page_num: Return an explicit page of the query response. If not given, gets all the pages
     :returns: A dictionary of entries
+    :rtype: dict
     """
     page = 1 if page_num == 0 else page_num
     entries_dict = {}
@@ -349,11 +351,10 @@ def process_request_old(cmr_query_url, response_processor, page_size=10, page_nu
 
     :param cmr_query_url: The whole URL, query params and all
     :param response_processor: A function that will process the returned json response
-    :param page_size: The number of entries per page from CMR. The default is the CMR
-        default value.
-    :param page_num: Return an explicit page of the query response. If not given, gets all
-        the pages
+    :param page_size: The number of entries per page from CMR. The default is the CMR default value.
+    :param page_num: Return an explicit page of the query response. If not given, gets all the pages
     :returns: A dictionary of entries
+    :deprecated: See process_request()
     """
     page = 1 if page_num == 0 else page_num
     entries_dict = {}
@@ -401,8 +402,9 @@ def process_request_old(cmr_query_url, response_processor, page_size=10, page_nu
 
 
 def get_granule_opendap_url(ccid, granule_ur, pretty=False, service='cmr.earthdata.nasa.gov'):
-    # TODO Write documentation
-    # TODO Is this function needed?
+    """
+    Get all the
+    """
     url_list = []
     url_dmr_test = {}
 
@@ -435,9 +437,8 @@ def get_session():
 
 def get_collection_granules_first_last(ccid, json_processor=collection_granule_and_url_dict, pretty=False,
                                        service='cmr.earthdata.nasa.gov'):
-    # TODO Write documentation; esp. WRT using collection_granule_and_url_dict
     """
-    This method uses the 'granules.jso' response which is probably not
+    This method uses the 'granules.json' response which is probably not
     the right way to ask about these granules.
 
     :deprecated: See get_collection_granules_umm_first_last(). jhrg 1/23/23
@@ -463,7 +464,17 @@ def get_collection_granules_first_last(ccid, json_processor=collection_granule_a
 
 def get_collection_granules_umm_first_last(ccid, json_processor=granule_ur_dict_2, pretty=False,
                                            service='cmr.earthdata.nasa.gov'):
-    # TODO Write documentation; esp. WRT using collection_granule_and_url_dict
+    """
+    This method uses the granules.umm_json_v1_4 response and finds the first and
+    last granules for a collection using the 'items' response from CMR.
+
+    :param ccid The Collection Concept ID
+    :param json_processor A function to parse the JSON from CMR
+    :param pretty Ask CMR to return a 'pretty' JSON response
+    :param service Which instance of CMR to query
+    :return: Return a dictionary that is the result of merging two dicts structured
+    like {ID1 : (Title1, URL1), ID2 : (Title2, URL2)} where ID is the granule ID.
+    """
     pretty = '&pretty=true' if pretty else ''
 
     # by default, CMR returns results with "sort_key = +start_date" returning the oldest granule
@@ -477,8 +488,9 @@ def get_collection_granules_umm_first_last(ccid, json_processor=granule_ur_dict_
 
     if len(newest_dict) != 1 and len(oldest_dict) != 1:
         raise CMRException(500, f"Expected at least one response item from CMR, got {len(newest_dict)+len(oldest_dict)}"
-                                f" while asking about {ccid}.")
+                                f" while asking about {ccid}, even though has_opendap_url was true for the collection.")
 
+    # Use host_patterns to see if the URL(s) is/are in the dictionaries. Maybe. jhrg 1/25/23
     return merge_dict(oldest_dict, newest_dict)
 
 
@@ -522,8 +534,7 @@ def get_related_urls(ccid, granule_ur, pretty=False, service='cmr.earthdata.nasa
     receives and the URLs that can be used to directly access data (and thus the DMR++
     if the data are in S3 and OPeNDAP-enabled).
 
-    :returns: A dictionary that holds all the RelatedUrls that have Type 'GET DATA' or
-        'USE SERVICE DATA.'
+    :returns: A dictionary that holds all the RelatedUrls that have Type 'GET DATA' or 'USE SERVICE DATA.'
     """
     pretty = '&pretty=true' if pretty else ''
     cmr_query_url = f'https://{service}/search/granules.umm_json_v1_4?collection_concept_id={ccid}&granule_ur={granule_ur}{pretty}'

--- a/cmr.py
+++ b/cmr.py
@@ -47,17 +47,35 @@ def is_item_feed(json_resp):
     return len(json_resp) > 0 and "items" in json_resp.keys() and "meta" in json_resp["items"][0]
 
 
+def is_meta_item(json_resp):
+    """
+    Does this JSON object have the 'meta' key that contains concept-id and native-id keys?
+    This function is used to protect various response processors
+    from responses that contain no entries or are malformed.
+
+    This function processes the return information from a granules.umm_json request.
+    """
+    return len(json_resp) > 0 and "meta" in json_resp.keys() \
+           and "concept-id" in json_resp["meta"].keys() \
+           and "native-id" in json_resp["meta"].keys()
+
+
 def is_granule_item(json_resp):
     """
     Does this JSON object have the 'RelatedUrls' key within a 'umm' key?
     This function is used to protect various response processors
     from responses that contain no entries or are malformed.
+
+    This function processes the return information from a granules.umm_json request.
     """
     return len(json_resp) > 0 and "umm" in json_resp.keys() and "RelatedUrls" in json_resp["umm"].keys()
 
 
 def collection_granules_dict(json_resp):
     """
+    This function processes the return information from a granules.json request.
+    Do not use it for a granules.umm_json request.
+
     :param: json_resp: CMR JSON response
     :return: A dictionary with the Granule id indexing the producer granule id and granule title
     :rtype: dict
@@ -78,9 +96,13 @@ def collection_granules_dict(json_resp):
 
 def collection_granule_and_url_dict(json_resp):
     """
+    This function processes the return information from a granules.json request.
+    Do not use it for a granules.umm_json request.
+
     :param: json_resp: CMR JSON response
     :return: A dictionary with the Granule id indexing the granule title and OPeNDAP URL
     :rtype: dict
+    :deprecated: jhrg 1/23/23
     """
     if not is_entry_feed(json_resp):
         return {}
@@ -144,10 +166,18 @@ def provider_id(json_resp):
 
 def granule_ur_dict(json_resp):
     """
-    Extract Related URLs from CMR JSON UMM
+    Extract Related URLs from CMR JSON UMM.
+
+    This function processes the return information from a granules.umm_json request.
+    Do not use it for a granules.json request.
+
+    Modified so that only URLs with the 'Subtype' 'OPENDAP DATA' are returned.
+    jhrg 1/23/23
+
     :param json_resp: CMR JSON UMM response
-    :return: The granule UR related URL info in a dictionary. Only 'GET DATA' and 'USE SERVICE API'
-        type URLs are included. Each is indexed using 'URL1', ..., 'URLn.'
+    :return: The granule UR related URL info in a dictionary. Only Type 'GET DATA'
+        or 'USE SERVICE API' with Subtype 'OPENDAP DATA' type URLs are included.
+        Each is indexed using 'URL1', ..., 'URLn.'
     :rtype: dict
     """
     # Check json_resp as above but for items, etc. jhrg 10/11/22
@@ -162,8 +192,52 @@ def granule_ur_dict(json_resp):
         for r_url in item["umm"]["RelatedUrls"]:
             if "Type" not in r_url or "URL" not in r_url:
                 continue
-            if "Type" in r_url and r_url["Type"] in ('GET DATA', 'USE SERVICE API'):
+            if "Type" in r_url and r_url["Type"] in ('GET DATA', 'USE SERVICE API') \
+                    and "Subtype" in r_url and r_url["Subtype"] == 'OPENDAP DATA':
                 dict_resp[f'URL{i}'] = (r_url["URL"])
+                i += 1
+
+    return dict_resp
+
+
+def granule_ur_dict_2(json_resp):
+    """
+    Extract Related URLs from CMR JSON UMM. This version returns a dictionary with
+    an ID, Title and URL like {ID : (Title, URL)}.
+
+    This function processes the return information from a granules.umm_json request.
+    Do not use it for a granules.json request.
+
+    Modified so that only URLs with the 'Subtype' 'OPENDAP DATA' are returned.
+    The response should use the 'concept-id' for ID, native-id for the Title
+    and 'URL' for the URL.
+    jhrg 1/23/23
+
+    :param json_resp: CMR JSON UMM response
+    :return: The granule UR related URL info in a dictionary. Only Type 'GET DATA'
+        or 'USE SERVICE API' with Subtype 'OPENDAP DATA' type URLs are included.
+        Each is indexed using 'URL1', ..., 'URLn.'
+    :rtype: dict
+    """
+    # Check json_resp as above but for items, etc. jhrg 10/11/22
+    if "items" not in json_resp.keys():
+        return {}
+
+    dict_resp = {}
+    i = 1
+    for item in json_resp["items"]:
+        if not (is_meta_item(item) and is_granule_item(item)):
+            continue
+        if "concept-id" not in item["meta"].keys() or "native-id" not in item["meta"].keys():
+            continue
+        concept_id = item["meta"]["concept-id"]
+        native_id = item["meta"]["native-id"]
+        for r_url in item["umm"]["RelatedUrls"]:
+            if "Type" not in r_url or "URL" not in r_url:
+                continue
+            if "Type" in r_url and r_url["Type"] in ('GET DATA', 'USE SERVICE API') \
+                    and "Subtype" in r_url and r_url["Subtype"] == 'OPENDAP DATA':
+                dict_resp[concept_id] = (native_id, r_url["URL"])
                 i += 1
 
     return dict_resp
@@ -362,6 +436,13 @@ def get_session():
 def get_collection_granules_first_last(ccid, json_processor=collection_granule_and_url_dict, pretty=False,
                                        service='cmr.earthdata.nasa.gov'):
     # TODO Write documentation; esp. WRT using collection_granule_and_url_dict
+    """
+    This method uses the 'granules.jso' response which is probably not
+    the right way to ask about these granules.
+
+    :deprecated: See get_collection_granules_umm_first_last(). jhrg 1/23/23
+    """
+
     pretty = '&pretty=true' if pretty else ''
 
     # by default, CMR returns results with "sort_key = +start_date" returning the oldest granule
@@ -371,6 +452,27 @@ def get_collection_granules_first_last(ccid, json_processor=collection_granule_a
     # Use "-start-date" to get the newest granule
     sort_key = '&sort_key=-start_date'
     cmr_query_url = f'https://{service}/search/granules.json?collection_concept_id={ccid}{sort_key}{pretty}'
+    newest_dict = process_request(cmr_query_url, json_processor, get_session(), page_size=1, page_num=1)
+
+    if len(newest_dict) != 1 and len(oldest_dict) != 1:
+        raise CMRException(500, f"Expected at least one response item from CMR, got {len(newest_dict)+len(oldest_dict)}"
+                                f" while asking about {ccid}.")
+
+    return merge_dict(oldest_dict, newest_dict)
+
+
+def get_collection_granules_umm_first_last(ccid, json_processor=granule_ur_dict_2, pretty=False,
+                                           service='cmr.earthdata.nasa.gov'):
+    # TODO Write documentation; esp. WRT using collection_granule_and_url_dict
+    pretty = '&pretty=true' if pretty else ''
+
+    # by default, CMR returns results with "sort_key = +start_date" returning the oldest granule
+    cmr_query_url = f'https://{service}/search/granules.umm_json_v1_4?collection_concept_id={ccid}{pretty}'
+    oldest_dict = process_request(cmr_query_url, json_processor, get_session(), page_size=1, page_num=1)
+
+    # Use "-start-date" to get the newest granule
+    sort_key = '&sort_key=-start_date'
+    cmr_query_url = f'{cmr_query_url}{sort_key}'
     newest_dict = process_request(cmr_query_url, json_processor, get_session(), page_size=1, page_num=1)
 
     if len(newest_dict) != 1 and len(oldest_dict) != 1:

--- a/cmr.py
+++ b/cmr.py
@@ -111,7 +111,7 @@ def collection_granule_and_url_dict(json_resp):
     # Look for the entry id, title, and OPeNDAP link.
     for entry in json_resp["feed"]["entry"]:
         if len(entry.keys() & ("id", "title", "links")) == 3:
-            # check for the OPeNDAP URL int eh 'links' array
+            # check for the OPeNDAP URL in the 'links' array
             for link in entry["links"]:
                 if "title" in link and link["title"].find("OPeNDAP") == 0:
                     dict_resp[entry["id"]] = (entry["title"], link["href"])

--- a/opendap_tests.py
+++ b/opendap_tests.py
@@ -24,7 +24,7 @@ def url_tester_ext(url_address, ext='.dmr'):
     :param: url_address: The url to be checked
     :return: A pass/fail of whether the url passes
     """
-    dmr_check = False
+    check = False
     try:
         print(".", end="", flush=True) if not quiet else False
         r = requests.get(url_address + ext)

--- a/regression_tests.py
+++ b/regression_tests.py
@@ -16,6 +16,7 @@ import xml.dom.minidom as minidom
 import time
 import concurrent.futures
 import os
+import itertools
 
 import cmr
 import opendap_tests
@@ -185,7 +186,7 @@ def main():
 
     parser.add_argument("-l", "--limit", help="limit the number of tests to the first N collections."
                                               "By default, run all the tests.",
-                        default=0)
+                        type=int, default=0)
 
     parser.add_argument("-d", "--dmr", help="Test getting the DMR response", action="store_true", default=True)
     parser.add_argument("-D", "--dap", help="Test getting the DAP response", action="store_true")
@@ -236,6 +237,11 @@ def main():
 
         # Get the collections for a given provider - this provides the CCID and title
         entries = cmr.get_provider_collections(args.provider, opendap=True, pretty=args.pretty)
+
+        # Truncate the entries if --limit is used
+        # NB: itertools.islice(sequence, start, stop, step) or itertools.islice(sequence, stop)
+        if args.limit > 0:
+            entries = dict(itertools.islice(entries.items(), args.limit))
 
         # For each collection...
         results = dict()

--- a/test/CMR_Responses.py
+++ b/test/CMR_Responses.py
@@ -1,4 +1,5 @@
-g1 = {'hits': 1, 'took': 152, 'items': [{'meta': {'concept-type': 'granule', 'concept-id': 'G2081588885-POCLOUD',
+g1 = {'hits': 1, 'took': 152, 'items': [{'meta': {'concept-type': 'granule',
+                                                  'concept-id': 'G2081588885-POCLOUD',
                                                   'revision-id': 4,
                                                   'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
                                                   'provider-id': 'POCLOUD',

--- a/test/CMR_Responses.py
+++ b/test/CMR_Responses.py
@@ -1,289 +1,348 @@
-
 g1 = {'hits': 1, 'took': 152, 'items': [{'meta': {'concept-type': 'granule', 'concept-id': 'G2081588885-POCLOUD',
-                                                 'revision-id': 4,
-                                                 'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
-                                                 'provider-id': 'POCLOUD',
-                                                 'format': 'application/vnd.nasa.cmr.umm+json',
-                                                 'revision-date': '2021-11-13T15:38:38.955Z'}, 'umm': {'RelatedUrls': [{
-                                                                                                                           'URL': 's3://podaac-ops-cumulus-protected/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
-                                                                                                                           'Type': 'GET DATA',
-                                                                                                                           'Description': 'This link provides direct download access via S3 to the granule.',
-                                                                                                                           'Format': 'Not provided'},
-                                                                                                                       {
-                                                                                                                           'URL': 'https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
-                                                                                                                           'Description': 'Download ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
-                                                                                                                           'Type': 'GET DATA',
-                                                                                                                           'Format': 'Not provided'},
-                                                                                                                       {
-                                                                                                                           'URL': 'https://archive.podaac.earthdata.nasa.gov/s3credentials',
-                                                                                                                           'Description': 'api endpoint to retrieve temporary credentials valid for same-region direct s3 access',
-                                                                                                                           'Type': 'VIEW RELATED INFORMATION',
-                                                                                                                           'Format': 'Not provided'},
-                                                                                                                       {
-                                                                                                                           'URL': 'https://opendap.earthdata.nasa.gov/collections/C2075141559-POCLOUD/granules/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
-                                                                                                                           'Type': 'USE SERVICE API',
-                                                                                                                           'Subtype': 'OPENDAP DATA',
-                                                                                                                           'Description': 'OPeNDAP request URL',
-                                                                                                                           'Format': 'Not provided'},
-                                                                                                                       {
-                                                                                                                           'URL': 'https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-public/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.wind_speed.png',
-                                                                                                                           'Type': 'GET RELATED VISUALIZATION',
-                                                                                                                           'Subtype': 'DIRECT DOWNLOAD',
-                                                                                                                           'MimeType': 'image/png',
-                                                                                                                           'Format': 'Not provided'},
-                                                                                                                       {
-                                                                                                                           'URL': 'https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-public/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.wind_dir.png',
-                                                                                                                           'Type': 'GET RELATED VISUALIZATION',
-                                                                                                                           'Subtype': 'DIRECT DOWNLOAD',
-                                                                                                                           'MimeType': 'image/png',
-                                                                                                                           'Format': 'Not provided'}],
-                                                                                                       'SpatialExtent': {
-                                                                                                           'HorizontalSpatialDomain': {
-                                                                                                               'Geometry': {
-                                                                                                                   'BoundingRectangles': [
-                                                                                                                       {
-                                                                                                                           'WestBoundingCoordinate': -180,
-                                                                                                                           'NorthBoundingCoordinate': 90,
-                                                                                                                           'EastBoundingCoordinate': 180,
-                                                                                                                           'SouthBoundingCoordinate': -90}],
-                                                                                                                   'GPolygons': [
-                                                                                                                       {
-                                                                                                                           'Boundary': {
-                                                                                                                               'Points': [
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -60.2646,
-                                                                                                                                       'Latitude': -1.3969},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -44.952,
-                                                                                                                                       'Latitude': 2.0636},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -57.9007,
-                                                                                                                                       'Latitude': 68.4171},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -61.1371,
-                                                                                                                                       'Latitude': 78.1792},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -65.2995,
-                                                                                                                                       'Latitude': 83.5822},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -73.2291,
-                                                                                                                                       'Latitude': 86.7838},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -89.5955,
-                                                                                                                                       'Latitude': 88.3994},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -180,
-                                                                                                                                       'Latitude': 89.0466},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -180,
-                                                                                                                                       'Latitude': 70.8422},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -167.0464,
-                                                                                                                                       'Latitude': 72.6145},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -153.3501,
-                                                                                                                                       'Latitude': 73.3851},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -139.1759,
-                                                                                                                                       'Latitude': 73.2066},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -125.3228,
-                                                                                                                                       'Latitude': 72.0221},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -114.2108,
-                                                                                                                                       'Latitude': 70.1182},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -104.3317,
-                                                                                                                                       'Latitude': 67.3481},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -95.9899,
-                                                                                                                                       'Latitude': 63.7585},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -89.1158,
-                                                                                                                                       'Latitude': 59.4233},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -80.0243,
-                                                                                                                                       'Latitude': 50.4127},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -72.5088,
-                                                                                                                                       'Latitude': 37.9593},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -66.1375,
-                                                                                                                                       'Latitude': 21.2485},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -60.2646,
-                                                                                                                                       'Latitude': -1.3969}]}},
-                                                                                                                       {
-                                                                                                                           'Boundary': {
-                                                                                                                               'Points': [
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 180,
-                                                                                                                                       'Latitude': 70.8422},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 180,
-                                                                                                                                       'Latitude': 89.0466},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 154.7225,
-                                                                                                                                       'Latitude': 88.5188},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 138.7755,
-                                                                                                                                       'Latitude': 87.3359},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 130.8919,
-                                                                                                                                       'Latitude': 85.438},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 125.8988,
-                                                                                                                                       'Latitude': 81.9975},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 122.9063,
-                                                                                                                                       'Latitude': 77.0202},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 120.3961,
-                                                                                                                                       'Latitude': 69.2094},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 106.0335,
-                                                                                                                                       'Latitude': -3.2595},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 100.949,
-                                                                                                                                       'Latitude': -21.951},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 95.5136,
-                                                                                                                                       'Latitude': -36.3035},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 88.658,
-                                                                                                                                       'Latitude': -48.3969},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 80.3427,
-                                                                                                                                       'Latitude': -57.525},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 70.0372,
-                                                                                                                                       'Latitude': -64.2444},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 57.0185,
-                                                                                                                                       'Latitude': -69.0187},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 34.6184,
-                                                                                                                                       'Latitude': -72.6562},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 8.3722,
-                                                                                                                                       'Latitude': -73.0522},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -15.2102,
-                                                                                                                                       'Latitude': -70.1741},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -24.7976,
-                                                                                                                                       'Latitude': -67.6073},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -32.711,
-                                                                                                                                       'Latitude': -64.4222},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -39.7072,
-                                                                                                                                       'Latitude': -60.3512},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -45.7052,
-                                                                                                                                       'Latitude': -55.4097},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -50.9437,
-                                                                                                                                       'Latitude': -49.4257},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -55.5855,
-                                                                                                                                       'Latitude': -42.2074},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -63.5655,
-                                                                                                                                       'Latitude': -23.2581},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -70.7512,
-                                                                                                                                       'Latitude': 4.1553},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -86.0718,
-                                                                                                                                       'Latitude': 0.6956},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -73.3974,
-                                                                                                                                       'Latitude': -65.9026},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -70.9958,
-                                                                                                                                       'Latitude': -75.2365},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -68.5275,
-                                                                                                                                       'Latitude': -80.8698},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -64.7462,
-                                                                                                                                       'Latitude': -84.756},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -59.1757,
-                                                                                                                                       'Latitude': -86.8936},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -50.0685,
-                                                                                                                                       'Latitude': -88.1405},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': -32.9909,
-                                                                                                                                       'Latitude': -88.8988},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 19.1304,
-                                                                                                                                       'Latitude': -89.3119},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 76.4237,
-                                                                                                                                       'Latitude': -88.7087},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 92.7763,
-                                                                                                                                       'Latitude': -87.5088},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 101.6992,
-                                                                                                                                       'Latitude': -84.7401},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 105.7232,
-                                                                                                                                       'Latitude': -80.4209},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 108.7677,
-                                                                                                                                       'Latitude': -72.4001},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 124.0714,
-                                                                                                                                       'Latitude': 5.3032},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 129.5645,
-                                                                                                                                       'Latitude': 24.8496},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 135.668,
-                                                                                                                                       'Latitude': 39.7891},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 143.3679,
-                                                                                                                                       'Latitude': 51.7589},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 152.8334,
-                                                                                                                                       'Latitude': 60.4781},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 164.7645,
-                                                                                                                                       'Latitude': 66.6799},
-                                                                                                                                   {
-                                                                                                                                       'Longitude': 180,
-                                                                                                                                       'Latitude': 70.8422}]}}]}}},
-                                                                                                       'ProviderDates': [
-                                                                                                           {
-                                                                                                               'Type': 'Insert',
-                                                                                                               'Date': '2021-06-28T02:03:37.204Z'},
-                                                                                                           {
-                                                                                                               'Type': 'Update',
-                                                                                                               'Date': '2021-06-28T02:03:37.220Z'}],
-                                                                                                       'CollectionReference': {
-                                                                                                           'Version': 'Operational/Near-Real-Time',
-                                                                                                           'ShortName': 'ASCATB-L2-25km'},
-                                                                                                       'DataGranule': {
-                                                                                                           'ArchiveAndDistributionInformation': [
-                                                                                                               {
-                                                                                                                   'SizeUnit': 'MB',
-                                                                                                                   'Size': 0.9198074340820312,
-                                                                                                                   'Checksum': {
-                                                                                                                       'Value': 'b12ce154bff14f384e933d5aa673ec6d',
-                                                                                                                       'Algorithm': 'MD5'},
-                                                                                                                   'Name': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
-                                                                                                                   'Format': 'Not provided'}],
-                                                                                                           'DayNightFlag': 'Unspecified',
-                                                                                                           'ProductionDateTime': '2013-06-10T10:05:39.000Z'},
-                                                                                                       'OrbitCalculatedSpatialDomains': [
-                                                                                                           {
-                                                                                                               'OrbitNumber': 588}],
-                                                                                                       'TemporalExtent': {
-                                                                                                           'RangeDateTime': {
-                                                                                                               'EndingDateTime': '2012-10-29T02:41:59.000Z',
-                                                                                                               'BeginningDateTime': '2012-10-29T01:00:01.000Z'}},
-                                                                                                       'GranuleUR': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2'}}]}
+                                                  'revision-id': 4,
+                                                  'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                                  'provider-id': 'POCLOUD',
+                                                  'format': 'application/vnd.nasa.cmr.umm+json',
+                                                  'revision-date': '2021-11-13T15:38:38.955Z'},
+                                         'umm': {'RelatedUrls': [{
+                                             'URL': 's3://podaac-ops-cumulus-protected/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
+                                             'Type': 'GET DATA',
+                                             'Description': 'This link provides direct download access via S3 to the granule.',
+                                             'Format': 'Not provided'},
+                                             {
+                                                 'URL': 'https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
+                                                 'Description': 'Download ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
+                                                 'Type': 'GET DATA',
+                                                 'Format': 'Not provided'},
+                                             {
+                                                 'URL': 'https://archive.podaac.earthdata.nasa.gov/s3credentials',
+                                                 'Description': 'api endpoint to retrieve temporary credentials valid for same-region direct s3 access',
+                                                 'Type': 'VIEW RELATED INFORMATION',
+                                                 'Format': 'Not provided'},
+                                             {
+                                                 'URL': 'https://opendap.earthdata.nasa.gov/collections/C2075141559-POCLOUD/granules/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                                 'Type': 'USE SERVICE API',
+                                                 'Subtype': 'OPENDAP DATA',
+                                                 'Description': 'OPeNDAP request URL',
+                                                 'Format': 'Not provided'},
+                                             {
+                                                 'URL': 'https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-public/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.wind_speed.png',
+                                                 'Type': 'GET RELATED VISUALIZATION',
+                                                 'Subtype': 'DIRECT DOWNLOAD',
+                                                 'MimeType': 'image/png',
+                                                 'Format': 'Not provided'},
+                                             {
+                                                 'URL': 'https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-public/ASCATB-L2-25km/ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.wind_dir.png',
+                                                 'Type': 'GET RELATED VISUALIZATION',
+                                                 'Subtype': 'DIRECT DOWNLOAD',
+                                                 'MimeType': 'image/png',
+                                                 'Format': 'Not provided'}],
+                                             'SpatialExtent': {
+                                                 'HorizontalSpatialDomain': {
+                                                     'Geometry': {
+                                                         'BoundingRectangles': [
+                                                             {
+                                                                 'WestBoundingCoordinate': -180,
+                                                                 'NorthBoundingCoordinate': 90,
+                                                                 'EastBoundingCoordinate': 180,
+                                                                 'SouthBoundingCoordinate': -90}],
+                                                         'GPolygons': [
+                                                             {
+                                                                 'Boundary': {
+                                                                     'Points': [
+                                                                         {
+                                                                             'Longitude': -60.2646,
+                                                                             'Latitude': -1.3969},
+                                                                         {
+                                                                             'Longitude': -44.952,
+                                                                             'Latitude': 2.0636},
+                                                                         {
+                                                                             'Longitude': -57.9007,
+                                                                             'Latitude': 68.4171},
+                                                                         {
+                                                                             'Longitude': -61.1371,
+                                                                             'Latitude': 78.1792},
+                                                                         {
+                                                                             'Longitude': -65.2995,
+                                                                             'Latitude': 83.5822},
+                                                                         {
+                                                                             'Longitude': -73.2291,
+                                                                             'Latitude': 86.7838},
+                                                                         {
+                                                                             'Longitude': -89.5955,
+                                                                             'Latitude': 88.3994},
+                                                                         {
+                                                                             'Longitude': -180,
+                                                                             'Latitude': 89.0466},
+                                                                         {
+                                                                             'Longitude': -180,
+                                                                             'Latitude': 70.8422},
+                                                                         {
+                                                                             'Longitude': -167.0464,
+                                                                             'Latitude': 72.6145},
+                                                                         {
+                                                                             'Longitude': -153.3501,
+                                                                             'Latitude': 73.3851},
+                                                                         {
+                                                                             'Longitude': -139.1759,
+                                                                             'Latitude': 73.2066},
+                                                                         {
+                                                                             'Longitude': -125.3228,
+                                                                             'Latitude': 72.0221},
+                                                                         {
+                                                                             'Longitude': -114.2108,
+                                                                             'Latitude': 70.1182},
+                                                                         {
+                                                                             'Longitude': -104.3317,
+                                                                             'Latitude': 67.3481},
+                                                                         {
+                                                                             'Longitude': -95.9899,
+                                                                             'Latitude': 63.7585},
+                                                                         {
+                                                                             'Longitude': -89.1158,
+                                                                             'Latitude': 59.4233},
+                                                                         {
+                                                                             'Longitude': -80.0243,
+                                                                             'Latitude': 50.4127},
+                                                                         {
+                                                                             'Longitude': -72.5088,
+                                                                             'Latitude': 37.9593},
+                                                                         {
+                                                                             'Longitude': -66.1375,
+                                                                             'Latitude': 21.2485},
+                                                                         {
+                                                                             'Longitude': -60.2646,
+                                                                             'Latitude': -1.3969}]}},
+                                                             {
+                                                                 'Boundary': {
+                                                                     'Points': [
+                                                                         {
+                                                                             'Longitude': 180,
+                                                                             'Latitude': 70.8422},
+                                                                         {
+                                                                             'Longitude': 180,
+                                                                             'Latitude': 89.0466},
+                                                                         {
+                                                                             'Longitude': 154.7225,
+                                                                             'Latitude': 88.5188},
+                                                                         {
+                                                                             'Longitude': 138.7755,
+                                                                             'Latitude': 87.3359},
+                                                                         {
+                                                                             'Longitude': 130.8919,
+                                                                             'Latitude': 85.438},
+                                                                         {
+                                                                             'Longitude': 125.8988,
+                                                                             'Latitude': 81.9975},
+                                                                         {
+                                                                             'Longitude': 122.9063,
+                                                                             'Latitude': 77.0202},
+                                                                         {
+                                                                             'Longitude': 120.3961,
+                                                                             'Latitude': 69.2094},
+                                                                         {
+                                                                             'Longitude': 106.0335,
+                                                                             'Latitude': -3.2595},
+                                                                         {
+                                                                             'Longitude': 100.949,
+                                                                             'Latitude': -21.951},
+                                                                         {
+                                                                             'Longitude': 95.5136,
+                                                                             'Latitude': -36.3035},
+                                                                         {
+                                                                             'Longitude': 88.658,
+                                                                             'Latitude': -48.3969},
+                                                                         {
+                                                                             'Longitude': 80.3427,
+                                                                             'Latitude': -57.525},
+                                                                         {
+                                                                             'Longitude': 70.0372,
+                                                                             'Latitude': -64.2444},
+                                                                         {
+                                                                             'Longitude': 57.0185,
+                                                                             'Latitude': -69.0187},
+                                                                         {
+                                                                             'Longitude': 34.6184,
+                                                                             'Latitude': -72.6562},
+                                                                         {
+                                                                             'Longitude': 8.3722,
+                                                                             'Latitude': -73.0522},
+                                                                         {
+                                                                             'Longitude': -15.2102,
+                                                                             'Latitude': -70.1741},
+                                                                         {
+                                                                             'Longitude': -24.7976,
+                                                                             'Latitude': -67.6073},
+                                                                         {
+                                                                             'Longitude': -32.711,
+                                                                             'Latitude': -64.4222},
+                                                                         {
+                                                                             'Longitude': -39.7072,
+                                                                             'Latitude': -60.3512},
+                                                                         {
+                                                                             'Longitude': -45.7052,
+                                                                             'Latitude': -55.4097},
+                                                                         {
+                                                                             'Longitude': -50.9437,
+                                                                             'Latitude': -49.4257},
+                                                                         {
+                                                                             'Longitude': -55.5855,
+                                                                             'Latitude': -42.2074},
+                                                                         {
+                                                                             'Longitude': -63.5655,
+                                                                             'Latitude': -23.2581},
+                                                                         {
+                                                                             'Longitude': -70.7512,
+                                                                             'Latitude': 4.1553},
+                                                                         {
+                                                                             'Longitude': -86.0718,
+                                                                             'Latitude': 0.6956},
+                                                                         {
+                                                                             'Longitude': -73.3974,
+                                                                             'Latitude': -65.9026},
+                                                                         {
+                                                                             'Longitude': -70.9958,
+                                                                             'Latitude': -75.2365},
+                                                                         {
+                                                                             'Longitude': -68.5275,
+                                                                             'Latitude': -80.8698},
+                                                                         {
+                                                                             'Longitude': -64.7462,
+                                                                             'Latitude': -84.756},
+                                                                         {
+                                                                             'Longitude': -59.1757,
+                                                                             'Latitude': -86.8936},
+                                                                         {
+                                                                             'Longitude': -50.0685,
+                                                                             'Latitude': -88.1405},
+                                                                         {
+                                                                             'Longitude': -32.9909,
+                                                                             'Latitude': -88.8988},
+                                                                         {
+                                                                             'Longitude': 19.1304,
+                                                                             'Latitude': -89.3119},
+                                                                         {
+                                                                             'Longitude': 76.4237,
+                                                                             'Latitude': -88.7087},
+                                                                         {
+                                                                             'Longitude': 92.7763,
+                                                                             'Latitude': -87.5088},
+                                                                         {
+                                                                             'Longitude': 101.6992,
+                                                                             'Latitude': -84.7401},
+                                                                         {
+                                                                             'Longitude': 105.7232,
+                                                                             'Latitude': -80.4209},
+                                                                         {
+                                                                             'Longitude': 108.7677,
+                                                                             'Latitude': -72.4001},
+                                                                         {
+                                                                             'Longitude': 124.0714,
+                                                                             'Latitude': 5.3032},
+                                                                         {
+                                                                             'Longitude': 129.5645,
+                                                                             'Latitude': 24.8496},
+                                                                         {
+                                                                             'Longitude': 135.668,
+                                                                             'Latitude': 39.7891},
+                                                                         {
+                                                                             'Longitude': 143.3679,
+                                                                             'Latitude': 51.7589},
+                                                                         {
+                                                                             'Longitude': 152.8334,
+                                                                             'Latitude': 60.4781},
+                                                                         {
+                                                                             'Longitude': 164.7645,
+                                                                             'Latitude': 66.6799},
+                                                                         {
+                                                                             'Longitude': 180,
+                                                                             'Latitude': 70.8422}]}}]}}},
+                                             'ProviderDates': [
+                                                 {
+                                                     'Type': 'Insert',
+                                                     'Date': '2021-06-28T02:03:37.204Z'},
+                                                 {
+                                                     'Type': 'Update',
+                                                     'Date': '2021-06-28T02:03:37.220Z'}],
+                                             'CollectionReference': {
+                                                 'Version': 'Operational/Near-Real-Time',
+                                                 'ShortName': 'ASCATB-L2-25km'},
+                                             'DataGranule': {
+                                                 'ArchiveAndDistributionInformation': [
+                                                     {
+                                                         'SizeUnit': 'MB',
+                                                         'Size': 0.9198074340820312,
+                                                         'Checksum': {
+                                                             'Value': 'b12ce154bff14f384e933d5aa673ec6d',
+                                                             'Algorithm': 'MD5'},
+                                                         'Name': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2.nc',
+                                                         'Format': 'Not provided'}],
+                                                 'DayNightFlag': 'Unspecified',
+                                                 'ProductionDateTime': '2013-06-10T10:05:39.000Z'},
+                                             'OrbitCalculatedSpatialDomains': [
+                                                 {
+                                                     'OrbitNumber': 588}],
+                                             'TemporalExtent': {
+                                                 'RangeDateTime': {
+                                                     'EndingDateTime': '2012-10-29T02:41:59.000Z',
+                                                     'BeginningDateTime': '2012-10-29T01:00:01.000Z'}},
+                                             'GranuleUR': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2'}}]}
+
+g2 = {'feed': {'updated': '2023-01-23T22:59:21.754Z',
+          'id': 'https://cmr.earthdata.nasa.gov:443/search/granules.json?collection_concept_id=C1238517289-GES_DISC&sort_key=-start_date&page_num=1&page_size=1',
+          'title': 'ECHO granule metadata',
+          'entry': [{'producer_granule_id': 'AIRS.2023.01.22.L3.RetStd_IR001.v6.0.33.0.G23023155742.hdf',
+                     'boxes': ['-90 -180 90 180'],
+                     'time_start': '2023-01-22T00:00:00.000Z',
+                     'updated': '2023-01-23T20:55:00.000Z',
+                     'dataset_id': 'AIRS/Aqua L3 Daily Standard Physical Retrieval (AIRS-only) 1 degree x 1 degree V006 (AIRS3STD) at GES DISC',
+                     'data_center': 'GES_DISC',
+                     'title': 'AIRS3STD.006:AIRS.2023.01.22.L3.RetStd_IR001.v6.0.33.0.G23023155742.hdf',
+                     'coordinate_system': 'CARTESIAN',
+                     'day_night_flag': 'UNSPECIFIED',
+                     'time_end': '2023-01-23T00:00:00.000Z',
+                     'id': 'G2595169100-GES_DISC',
+                     'original_format': 'ECHO10',
+                     'granule_size': '335.848421096802',
+                     'browse_flag': False,
+                     'collection_concept_id': 'C1238517289-GES_DISC',
+                     'online_access_flag': True,
+                     'links': [{'rel': 'http://esipfed.org/ns/fedsearch/1.1/data#',
+                                'hreflang': 'en-US',
+                                'href': 'https://acdisc.gesdisc.eosdis.nasa.gov/data//Aqua_AIRS_Level3/AIRS3STD.006/2023/AIRS.2023.01.22.L3.RetStd_IR001.v6.0.33.0.G23023155742.hdf'},
+                               {'rel': 'http://esipfed.org/ns/fedsearch/1.1/service#',
+                                'type': 'application/x-hdf',
+                                'title': 'The OPENDAP location for the granule. (GET DATA : OPENDAP DATA)',
+                                'hreflang': 'en-US',
+                                'href': 'https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRS3STD.006/2023/AIRS.2023.01.22.L3.RetStd_IR001.v6.0.33.0.G23023155742.hdf'},
+                               {'inherited': True, 'rel': 'http://esipfed.org/ns/fedsearch/1.1/metadata#',
+                                'hreflang': 'en-US',
+                                'href': 'https://disc.gsfc.nasa.gov/datacollection/AIRS3STD_006.html'},
+                               {'inherited': True,
+                                'rel': 'http://esipfed.org/ns/fedsearch/1.1/data#',
+                                'hreflang': 'en-US',
+                                'href': 'https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRS3STD.006/'},
+                               {'inherited': True,
+                                'rel': 'http://esipfed.org/ns/fedsearch/1.1/service#',
+                                'hreflang': 'en-US',
+                                'href': 'https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRS3STD.006/contents.html'},
+                               {'inherited': True,
+                                'rel': 'http://esipfed.org/ns/fedsearch/1.1/data#',
+                                'hreflang': 'en-US',
+                                'href': 'https://search.earthdata.nasa.gov/search?q=AIRS3STD+006'},
+                               {'inherited': True,
+                                'rel': 'http://esipfed.org/ns/fedsearch/1.1/metadata#',
+                                'hreflang': 'en-US',
+                                'href': 'https://airs.jpl.nasa.gov/index.html'},
+                               {'inherited': True,
+                                'rel': 'http://esipfed.org/ns/fedsearch/1.1/documentation#',
+                                'hreflang': 'en-US',
+                                'href': 'https://disc.gsfc.nasa.gov/information/documents?title=AIRS%20Documentation'},
+                               {'inherited': True,
+                                'rel': 'http://esipfed.org/ns/fedsearch/1.1/documentation#',
+                                'hreflang': 'en-US',
+                                'href': 'https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf'},
+                               {'inherited': True,
+                                'rel': 'http://esipfed.org/ns/fedsearch/1.1/documentation#',
+                                'hreflang': 'en-US',
+                                'href': 'https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf'}]}]}}

--- a/test/test_cmr.py
+++ b/test/test_cmr.py
@@ -77,6 +77,9 @@ class TestCMR(unittest.TestCase):
         self.assertRaisesRegex(TypeError, ".*cmr.merge.*", cmr.merge_dict, [], {'c': 'd'})
         self.assertRaisesRegex(TypeError, ".*cmr.merge.*", cmr.merge_dict, {'c': 'd'}, [])
 
+    def test_get_collection_granules_first_last(self):
+        self.assertEqual({}, cmr.get_collection_granules_first_last("C1238517289-GES_DISC"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_cmr.py
+++ b/test/test_cmr.py
@@ -24,12 +24,12 @@ class TestCMR(unittest.TestCase):
     # That array holds dictionaries, where each value of the key 'umm' is and array of...
     # dictionaries. gads.
     g1 = {'items': [{'umm': {'RelatedUrls': [{'URL': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc',
-                                              'Type': 'GET DATA'},
+                                              'Type': 'GET DATA', 'Subtype': 'OPENDAP DATA'},
                                              {'URL': 'https://archive/250_2101_ovw.l2.nc',
-                                              'Type': 'GET DATA'}]}}]}
+                                              'Type': 'GET DATA', 'Subtype': 'OPENDAP DATA'}]}}]}
     # this has one element of the RelatedUrls array with both Type and URL and one missing Type
     g12 = {'items': [{'umm': {'RelatedUrls': [{'URL': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc',
-                                               'Type': 'GET DATA'},
+                                               'Type': 'GET DATA', 'Subtype': 'OPENDAP DATA'},
                                               {'URL': 'https://archive/250_2101_ovw.l2.nc'}]}}]}
 
     # These are all missing things
@@ -76,9 +76,6 @@ class TestCMR(unittest.TestCase):
         # In the following, just test a small and unique part of the error message.
         self.assertRaisesRegex(TypeError, ".*cmr.merge.*", cmr.merge_dict, [], {'c': 'd'})
         self.assertRaisesRegex(TypeError, ".*cmr.merge.*", cmr.merge_dict, {'c': 'd'}, [])
-
-    def test_get_collection_granules_first_last(self):
-        self.assertEqual({}, cmr.get_collection_granules_first_last("C1238517289-GES_DISC"))
 
 
 if __name__ == '__main__':

--- a/test/test_cmr.py
+++ b/test/test_cmr.py
@@ -1,4 +1,3 @@
-
 """
 Test functions in the pydmr cmr module.
 """
@@ -12,7 +11,8 @@ class TestCMR(unittest.TestCase):
                               {'id': 'C5678-Provider', 'title': 'Another title'}]}}
 
     # These include producer_granule_id and granule_count info
-    d2 = {'feed': {'entry': [{'id': 'C1234-Provider', 'title': 'A title with spaces', 'producer_granule_id': 'G1234', 'granule_count': 10}]}}
+    d2 = {'feed': {'entry': [
+        {'id': 'C1234-Provider', 'title': 'A title with spaces', 'producer_granule_id': 'G1234', 'granule_count': 10}]}}
     d22 = {'feed': {'entry': [{'id': 'C1234-Provider', 'title': 'A title with spaces', 'producer_granule_id': 'G1234'},
                               {'id': 'C5678-Provider', 'title': 'Another title', 'granule_count': 10}]}}
 
@@ -38,20 +38,71 @@ class TestCMR(unittest.TestCase):
     g3 = {'items': [{'umm': {}}]}
     g4 = {'items': []}
 
+    # valid 'items' from a granule query are a dictionary where the value is an array.
+    # That array holds dictionaries, where each value of the key 'umm' is and array of...
+    # dictionaries. gads.
+    g6 = {'items': [{'meta': {'concept-type': 'granule',
+                              'concept-id': 'G2081588885-POCLOUD',
+                              'revision-id': 4,
+                              'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                              'provider-id': 'POCLOUD',
+                              'format': 'application/vnd.nasa.cmr.umm+json',
+                              'revision-date': '2021-11-13T15:38:38.955Z'},
+                     'umm': {'RelatedUrls': [{'URL': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc',
+                                              'Type': 'GET DATA', 'Subtype': 'OPENDAP DATA'},
+                                             {'URL': 'https://archive/250_2101_ovw.l2.nc', 'Type': 'GET DATA'}]}}]}
+    # this has one element of the RelatedUrls array with both Type and URL and one missing Type
+    g62 = {'items': [{'meta': {'concept-type': 'granule',
+                               'concept-id': 'G2081588885-POCLOUD',
+                               'revision-id': 4,
+                               'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                               'provider-id': 'POCLOUD',
+                               'format': 'application/vnd.nasa.cmr.umm+json',
+                               'revision-date': '2021-11-13T15:38:38.955Z'},
+                      'umm': {'RelatedUrls': [{'URL': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc',
+                                               'Type': 'USE SERVICE API', 'Subtype': 'OPENDAP DATA'},
+                                              {'URL': 'https://archive/250_2101_ovw.l2.nc'}]}}]}
+
+    g7 = {'items': [{'meta': {'concept-type': 'granule',
+                              'concept-id': 'G2081588885-POCLOUD',
+                              'revision-id': 4,
+                              # 'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                              'revision-date': '2021-11-13T15:38:38.955Z'},
+                     'umm': {'RelatedUrls': {'URL': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc'}}}]}
+    g72 = {'items': [{'meta': {'concept-type': 'granule',
+                               # 'concept-id': 'G2081588885-POCLOUD',
+                               'revision-id': 4,
+                               # 'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                               'revision-date': '2021-11-13T15:38:38.955Z'},
+                      'umm': {'RelatedUrls': {'URL': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc'}}}]}
+    g73 = {'items': [{'meta': {'concept-type': 'granule',
+                               # 'concept-id': 'G2081588885-POCLOUD',
+                               'revision-id': 4,
+                               'native-id': 'ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                               'revision-date': '2021-11-13T15:38:38.955Z'},
+                      'umm': {'RelatedUrls': {'URL': 's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc'}}}]}
+    g74 = {'items': [{'umm': {'RelatedUrls': {'Type': 'GET DATA', 'Subtype': 'OPENDAP DATA', 'URL': 'stuff'}}}]}
+    g75 = {'items': [{'umm': {}}]}
+    g76 = {'items': []}
+
     def test_collection_granules_dict(self):
         self.assertEqual({'C1234-Provider': 'A title with spaces'}, cmr.collection_granules_dict(self.d1))
-        self.assertEqual({'C1234-Provider': 'A title with spaces', 'C5678-Provider': 'Another title'}, cmr.collection_granules_dict(self.d12))
+        self.assertEqual({'C1234-Provider': 'A title with spaces', 'C5678-Provider': 'Another title'},
+                         cmr.collection_granules_dict(self.d12))
         self.assertEqual({'C1234-Provider': ('A title with spaces', 'G1234')}, cmr.collection_granules_dict(self.d2))
-        self.assertEqual({'C1234-Provider': ('A title with spaces', 'G1234'), 'C5678-Provider': 'Another title'}, cmr.collection_granules_dict(self.d22))
+        self.assertEqual({'C1234-Provider': ('A title with spaces', 'G1234'), 'C5678-Provider': 'Another title'},
+                         cmr.collection_granules_dict(self.d22))
         self.assertEqual({}, cmr.collection_granules_dict(self.d3))
         self.assertEqual({}, cmr.collection_granules_dict(self.d4))
         self.assertEqual({}, cmr.collection_granules_dict(self.d5))
 
     def test_provider_collections_dict(self):
         self.assertEqual({'C1234-Provider': 'A title with spaces'}, cmr.provider_collections_dict(self.d1))
-        self.assertEqual({'C1234-Provider': 'A title with spaces', 'C5678-Provider': 'Another title'}, cmr.provider_collections_dict(self.d12))
+        self.assertEqual({'C1234-Provider': 'A title with spaces', 'C5678-Provider': 'Another title'},
+                         cmr.provider_collections_dict(self.d12))
         self.assertEqual({'C1234-Provider': (10, 'A title with spaces')}, cmr.provider_collections_dict(self.d2))
-        self.assertEqual({'C1234-Provider': 'A title with spaces', 'C5678-Provider': (10, 'Another title')}, cmr.provider_collections_dict(self.d22))
+        self.assertEqual({'C1234-Provider': 'A title with spaces', 'C5678-Provider': (10, 'Another title')},
+                         cmr.provider_collections_dict(self.d22))
         self.assertEqual({}, cmr.provider_collections_dict(self.d3))
         self.assertEqual({}, cmr.provider_collections_dict(self.d4))
         self.assertEqual({}, cmr.provider_collections_dict(self.d5))
@@ -66,6 +117,22 @@ class TestCMR(unittest.TestCase):
         self.assertEqual({}, cmr.granule_ur_dict(self.g21))
         self.assertEqual({}, cmr.granule_ur_dict(self.g3))
         self.assertEqual({}, cmr.granule_ur_dict(self.g4))
+
+    def test_granule_ur_dict_2(self):
+        # granule_ur_dict_2 should return a dictionary like {ID : (Title, URL)}.
+        self.assertEqual({'G2081588885-POCLOUD': ('ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                                  's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc')},
+                         cmr.granule_ur_dict_2(self.g6))
+        self.assertEqual({'G2081588885-POCLOUD': ('ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                                  's3://podaac/metopb_00588_eps_o_250_2101_ovw.l2.nc')},
+                         cmr.granule_ur_dict_2(self.g62))
+
+        self.assertEqual({}, cmr.granule_ur_dict_2(self.g7))
+        self.assertEqual({}, cmr.granule_ur_dict_2(self.g72))
+        self.assertEqual({}, cmr.granule_ur_dict_2(self.g73))
+        self.assertEqual({}, cmr.granule_ur_dict_2(self.g74))
+        self.assertEqual({}, cmr.granule_ur_dict_2(self.g75))
+        self.assertEqual({}, cmr.granule_ur_dict_2(self.g76))
 
     def test_merge(self):
         self.assertEqual({'a': 'b', 'c': 'd'}, cmr.merge_dict({'a': 'b'}, {'c': 'd'}))

--- a/test/test_regression_tests.py
+++ b/test/test_regression_tests.py
@@ -1,0 +1,44 @@
+"""
+Test functions in the pydmr regression_tests module.
+"""
+import unittest
+import regression_tests
+
+
+class TestRegressionTests(unittest.TestCase):
+    def test_is_opendap_cloud_url(self):
+        self.assertTrue(regression_tests.is_opendap_cloud_url('http://opendap.earthdata.nasa.gov/hello/world.h5'),
+                        "Should pass")
+        self.assertTrue(regression_tests.is_opendap_cloud_url('https://opendap.earthdata.nasa.gov/foo/bar.h5'),
+                        "Should pass")
+        self.assertFalse(regression_tests.is_opendap_cloud_url('http://opendap.uat.earthdata.nasa.gov/k/r.h5'),
+                         "Fails because 'opendap.uat...'")
+        self.assertFalse(regression_tests.is_opendap_cloud_url('http://podaac.nasa.gov/k/r.h5'),
+                         "Fails because 'podaac...'")
+
+
+    pass1 = {'G2081588885-POCLOUD': ('ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                     'https://opendap.earthdata.nasa.gov/foo/bar.h5'),
+             'G2081589999-POCLOUD': ('ascat_20231029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                     'https://opendap.earthdata.nasa.gov/hello/world.h5')}
+    fail2 = {'G2081588885-POCLOUD': ('ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                     'https://opendap.uat.earthdata.nasa.gov/foo/bar.h5'),  # opendap.uat...
+             'G2081589999-POCLOUD': ('ascat_20231029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                     'https://opendap.earthdata.nasa.gov/hello/world.h5')}
+    fail3 = {'G2081588885-POCLOUD': ('ascat_20121029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                     'https://opendap.earthdata.nasa.gov/foo/bar.h5'),
+             'G2081589999-POCLOUD': ('ascat_20231029_010001_metopb_00588_eps_o_250_2101_ovw.l2',
+                                     'https://podaac.machine.domain.tld/hello/world.h5')}   # podaac...
+
+    def test_has_only_opendap_urls(self):
+        self.assertTrue(regression_tests.has_only_cloud_opendap_urls(self.pass1), "Should pass")
+        self.assertFalse(regression_tests.has_only_cloud_opendap_urls(self.fail2), "Fails because 'opendap.uat...'")
+        self.assertFalse(regression_tests.has_only_cloud_opendap_urls(self.fail3), "Fails because 'podaac...'")
+
+    def test_formatted_urls(self):
+        self.assertEqual(regression_tests.formatted_urls(self.pass1),
+                         "https://opendap.earthdata.nasa.gov/foo/bar.h5, https://opendap.earthdata.nasa.gov/hello/world.h5",
+                         "Should pass")
+        self.assertEqual(regression_tests.formatted_urls(self.fail3),
+                         "https://opendap.earthdata.nasa.gov/foo/bar.h5, https://podaac.machine.domain.tld/hello/world.h5",
+                         "Should pass")


### PR DESCRIPTION
This PR contains a fix for the way we look for 'opendap urls' in CMR. There are some new options so that the old behavior can be selected and some additional behavior controlled. The additional behavior provides a way to choose between testing cloud-only URLs (the default) and any URL. If the default is used, then non-cloud URLs we find in CMR will be reported using an 'info' message. 

I also added a --limit option (defaults to no limit) that provides a way to test only the first N collections for a given provider. This makes for a simplified (faster) testing process when actually using CMR.

I also added a few unit-tests for new code in cmr.py and regression_tests.py.